### PR TITLE
Improve NYTBee scraper robustness

### DIFF
--- a/scrape_nytbee.py
+++ b/scrape_nytbee.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Scrape and output content from a NYTBee page."""
+from __future__ import annotations
+
+import argparse
+from html.parser import HTMLParser
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+DEFAULT_URL = "https://nytbee.com/Bee_20260130.html"
+USER_AGENT = "Mozilla/5.0 (compatible; NYTBeeScraper/1.0)"
+
+
+class TagTextExtractor(HTMLParser):
+    """Extract visible text from a specific tag."""
+
+    def __init__(self, tag: str) -> None:
+        super().__init__(convert_charrefs=True)
+        self.tag = tag
+        self.depth = 0
+        self._texts: list[str] = []
+        self._skip_depth = 0
+
+    @property
+    def text(self) -> str:
+        lines = [line.strip() for line in "\n".join(self._texts).splitlines()]
+        return "\n".join([line for line in lines if line])
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+            return
+        if tag == self.tag:
+            self.depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if tag == self.tag and self.depth:
+            self.depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self.depth and not self._skip_depth:
+            self._texts.append(data)
+
+
+def fetch_html(url: str, timeout: int = 20) -> str:
+    request = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(request, timeout=timeout) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset, errors="replace")
+
+
+def extract_content(html: str) -> str:
+    for tag in ("main", "body"):
+        extractor = TagTextExtractor(tag)
+        extractor.feed(html)
+        content = extractor.text
+        if content:
+            return content
+    return ""
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scrape and print page content from NYTBee."
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="NYTBee page URL to scrape",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=20,
+        help="Request timeout in seconds",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional output file path to write extracted text",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        html = fetch_html(args.url, timeout=args.timeout)
+    except HTTPError as exc:
+        print(f"HTTP error fetching {args.url}: {exc}")
+        return 1
+    except URLError as exc:
+        print(f"URL error fetching {args.url}: {exc}")
+        return 1
+
+    content = extract_content(html)
+    if not content:
+        print("No content extracted from the page.")
+        return 1
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.write("\n")
+    else:
+        print(content)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Remove reliance on third-party packages and make the scraper more resilient so it runs in constrained environments and extracts page text reliably.

### Description
- Replace `requests`/`BeautifulSoup` with stdlib `urllib.request` and `html.parser` and add a `TagTextExtractor` to collect visible text from specific tags while skipping `script`/`style` content.
- Implement `fetch_html` that sends a `User-Agent` header and respects a configurable timeout, and `extract_content` that prefers the `<main>` element and falls back to `<body>`.
- Add CLI flags `--timeout` and `--output` to control request timeout and optional output file writing.
- Improve error handling to report `HTTPError` and `URLError` and return non-zero exit codes when fetching or extraction fails.

### Testing
- Ran `python scrape_nytbee.py --url https://nytbee.com/Bee_20260130.html --timeout 20 | head -n 20`, which failed with a network `403 Forbidden` (tunnel/proxy) so live fetch could not be validated in this environment.
- An earlier run of the previous implementation failed with `ModuleNotFoundError: No module named 'requests'`, which motivated removing that dependency and using the standard library instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce3f003648333995088ff3d959b43)