### PR TITLE
Add Jupyter notebook for NYTBee scraper

### DIFF
--- a/scrape_nytbee.ipynb
+++ b/scrape_nytbee.ipynb
@@ -1,0 +1,138 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# NYTBee Scraper\n",
+        "\n",
+        "This notebook fetches a NYTBee page and extracts visible text from the page's main content.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from __future__ import annotations\n",
+        "\n",
+        "import argparse\n",
+        "from html.parser import HTMLParser\n",
+        "from typing import Optional\n",
+        "from urllib.error import HTTPError, URLError\n",
+        "from urllib.request import Request, urlopen\n",
+        "\n",
+        "DEFAULT_URL = \"https://nytbee.com/Bee_20260130.html\"\n",
+        "USER_AGENT = \"Mozilla/5.0 (compatible; NYTBeeScraper/1.0)\"\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "class TagTextExtractor(HTMLParser):\n",
+        "    \"\"\"Extract visible text from a specific tag.\"\"\"\n",
+        "\n",
+        "    def __init__(self, tag: str) -> None:\n",
+        "        super().__init__(convert_charrefs=True)\n",
+        "        self.tag = tag\n",
+        "        self.depth = 0\n",
+        "        self._texts: list[str] = []\n",
+        "        self._skip_depth = 0\n",
+        "\n",
+        "    @property\n",
+        "    def text(self) -> str:\n",
+        "        lines = [line.strip() for line in \"\\n\".join(self._texts).splitlines()]\n",
+        "        return \"\\n\".join([line for line in lines if line])\n",
+        "\n",
+        "    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:\n",
+        "        if tag in {\"script\", \"style\"}:\n",
+        "            self._skip_depth += 1\n",
+        "            return\n",
+        "        if tag == self.tag:\n",
+        "            self.depth += 1\n",
+        "\n",
+        "    def handle_endtag(self, tag: str) -> None:\n",
+        "        if tag in {\"script\", \"style\"} and self._skip_depth:\n",
+        "            self._skip_depth -= 1\n",
+        "            return\n",
+        "        if tag == self.tag and self.depth:\n",
+        "            self.depth -= 1\n",
+        "\n",
+        "    def handle_data(self, data: str) -> None:\n",
+        "        if self.depth and not self._skip_depth:\n",
+        "            self._texts.append(data)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def fetch_html(url: str, timeout: int = 20) -> str:\n",
+        "    request = Request(url, headers={\"User-Agent\": USER_AGENT})\n",
+        "    with urlopen(request, timeout=timeout) as response:\n",
+        "        charset = response.headers.get_content_charset() or \"utf-8\"\n",
+        "        return response.read().decode(charset, errors=\"replace\")\n",
+        "\n",
+        "\n",
+        "def extract_content(html: str) -> str:\n",
+        "    for tag in (\"main\", \"body\"):\n",
+        "        extractor = TagTextExtractor(tag)\n",
+        "        extractor.feed(html)\n",
+        "        content = extractor.text\n",
+        "        if content:\n",
+        "            return content\n",
+        "    return \"\"\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Fetch and extract content\n",
+        "\n",
+        "Set `url` to the NYTBee page you want to scrape, then run the cell.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "url = DEFAULT_URL\n",
+        "\n",
+        "try:\n",
+        "    html = fetch_html(url, timeout=20)\n",
+        "except HTTPError as exc:\n",
+        "    raise SystemExit(f\"HTTP error fetching {url}: {exc}\")\n",
+        "except URLError as exc:\n",
+        "    raise SystemExit(f\"URL error fetching {url}: {exc}\")\n",
+        "\n",
+        "content = extract_content(html)\n",
+        "if not content:\n",
+        "    raise SystemExit(\"No content extracted from the page.\")\n",
+        "\n",
+        "print(content)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive Jupyter notebook version of the existing NYTBee scraping script to make it easier to run and experiment with the scraper in a notebook environment.

### Description
- Add `scrape_nytbee.ipynb` which reproduces the scraper logic split into cells: imports and constants, the `TagTextExtractor` class, `fetch_html`/`extract_content` functions, and a run cell that fetches and prints the page content.

### Testing
- Attempted to generate the notebook via `nbformat` which failed with `ModuleNotFoundError: No module named 'nbformat'`, then generated the notebook using a Python `json.dump` approach which wrote `scrape_nytbee.ipynb` successfully and the file was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ceaa81d08833385cde27f0fb6188d)