### PR TITLE
Update notebook to extract items from `main-answer-list`

### DIFF
--- a/scrape_nytbee.ipynb
+++ b/scrape_nytbee.ipynb
@@ -1,138 +1,157 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# NYTBee Scraper\n",
-        "\n",
-        "This notebook fetches a NYTBee page and extracts visible text from the page's main content.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from __future__ import annotations\n",
-        "\n",
-        "import argparse\n",
-        "from html.parser import HTMLParser\n",
-        "from typing import Optional\n",
-        "from urllib.error import HTTPError, URLError\n",
-        "from urllib.request import Request, urlopen\n",
-        "\n",
-        "DEFAULT_URL = \"https://nytbee.com/Bee_20260130.html\"\n",
-        "USER_AGENT = \"Mozilla/5.0 (compatible; NYTBeeScraper/1.0)\"\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "class TagTextExtractor(HTMLParser):\n",
-        "    \"\"\"Extract visible text from a specific tag.\"\"\"\n",
-        "\n",
-        "    def __init__(self, tag: str) -> None:\n",
-        "        super().__init__(convert_charrefs=True)\n",
-        "        self.tag = tag\n",
-        "        self.depth = 0\n",
-        "        self._texts: list[str] = []\n",
-        "        self._skip_depth = 0\n",
-        "\n",
-        "    @property\n",
-        "    def text(self) -> str:\n",
-        "        lines = [line.strip() for line in \"\\n\".join(self._texts).splitlines()]\n",
-        "        return \"\\n\".join([line for line in lines if line])\n",
-        "\n",
-        "    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:\n",
-        "        if tag in {\"script\", \"style\"}:\n",
-        "            self._skip_depth += 1\n",
-        "            return\n",
-        "        if tag == self.tag:\n",
-        "            self.depth += 1\n",
-        "\n",
-        "    def handle_endtag(self, tag: str) -> None:\n",
-        "        if tag in {\"script\", \"style\"} and self._skip_depth:\n",
-        "            self._skip_depth -= 1\n",
-        "            return\n",
-        "        if tag == self.tag and self.depth:\n",
-        "            self.depth -= 1\n",
-        "\n",
-        "    def handle_data(self, data: str) -> None:\n",
-        "        if self.depth and not self._skip_depth:\n",
-        "            self._texts.append(data)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "def fetch_html(url: str, timeout: int = 20) -> str:\n",
-        "    request = Request(url, headers={\"User-Agent\": USER_AGENT})\n",
-        "    with urlopen(request, timeout=timeout) as response:\n",
-        "        charset = response.headers.get_content_charset() or \"utf-8\"\n",
-        "        return response.read().decode(charset, errors=\"replace\")\n",
-        "\n",
-        "\n",
-        "def extract_content(html: str) -> str:\n",
-        "    for tag in (\"main\", \"body\"):\n",
-        "        extractor = TagTextExtractor(tag)\n",
-        "        extractor.feed(html)\n",
-        "        content = extractor.text\n",
-        "        if content:\n",
-        "            return content\n",
-        "    return \"\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Fetch and extract content\n",
-        "\n",
-        "Set `url` to the NYTBee page you want to scrape, then run the cell.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "url = DEFAULT_URL\n",
-        "\n",
-        "try:\n",
-        "    html = fetch_html(url, timeout=20)\n",
-        "except HTTPError as exc:\n",
-        "    raise SystemExit(f\"HTTP error fetching {url}: {exc}\")\n",
-        "except URLError as exc:\n",
-        "    raise SystemExit(f\"URL error fetching {url}: {exc}\")\n",
-        "\n",
-        "content = extract_content(html)\n",
-        "if not content:\n",
-        "    raise SystemExit(\"No content extracted from the page.\")\n",
-        "\n",
-        "print(content)\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.x"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NYTBee Scraper\n",
+    "\n",
+    "This notebook fetches a NYTBee page and extracts the list items from the main answer list.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import argparse\n",
+    "from html.parser import HTMLParser\n",
+    "from typing import Optional\n",
+    "from urllib.error import HTTPError, URLError\n",
+    "from urllib.request import Request, urlopen\n",
+    "\n",
+    "DEFAULT_URL = \"https://nytbee.com/Bee_20260130.html\"\n",
+    "USER_AGENT = \"Mozilla/5.0 (compatible; NYTBeeScraper/1.0)\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MainAnswerListParser(HTMLParser):\n",
+    "    \"\"\"Extract list items from the main answer list.\"\"\"\n",
+    "\n",
+    "    def __init__(self) -> None:\n",
+    "        super().__init__(convert_charrefs=True)\n",
+    "        self._div_depth = 0\n",
+    "        self._target_div_depth: Optional[int] = None\n",
+    "        self._ul_depth = 0\n",
+    "        self._li_stack: list[list[str]] = []\n",
+    "        self._items: list[str] = []\n",
+    "        self._skip_depth = 0\n",
+    "\n",
+    "    @property\n",
+    "    def items(self) -> list[str]:\n",
+    "        return self._items\n",
+    "\n",
+    "    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:\n",
+    "        if tag in {\"script\", \"style\"}:\n",
+    "            self._skip_depth += 1\n",
+    "            return\n",
+    "        if tag == \"div\":\n",
+    "            self._div_depth += 1\n",
+    "            if self._target_div_depth is None and dict(attrs).get(\"id\") == \"main-answer-list\":\n",
+    "                self._target_div_depth = self._div_depth\n",
+    "            return\n",
+    "        if self._target_div_depth is None or self._div_depth < self._target_div_depth:\n",
+    "            return\n",
+    "        if tag == \"ul\":\n",
+    "            self._ul_depth += 1\n",
+    "            return\n",
+    "        if tag == \"li\" and self._ul_depth:\n",
+    "            self._li_stack.append([])\n",
+    "\n",
+    "    def handle_endtag(self, tag: str) -> None:\n",
+    "        if tag in {\"script\", \"style\"} and self._skip_depth:\n",
+    "            self._skip_depth -= 1\n",
+    "            return\n",
+    "        if tag == \"li\" and self._li_stack:\n",
+    "            text = \"\".join(self._li_stack.pop()).strip()\n",
+    "            if text:\n",
+    "                self._items.append(text)\n",
+    "            return\n",
+    "        if tag == \"ul\" and self._ul_depth:\n",
+    "            self._ul_depth -= 1\n",
+    "            return\n",
+    "        if tag == \"div\":\n",
+    "            if self._target_div_depth is not None and self._div_depth == self._target_div_depth:\n",
+    "                self._target_div_depth = None\n",
+    "            if self._div_depth:\n",
+    "                self._div_depth -= 1\n",
+    "\n",
+    "    def handle_data(self, data: str) -> None:\n",
+    "        if self._skip_depth or not self._li_stack:\n",
+    "            return\n",
+    "        self._li_stack[-1].append(data)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_html(url: str, timeout: int = 20) -> str:\n",
+    "    request = Request(url, headers={\"User-Agent\": USER_AGENT})\n",
+    "    with urlopen(request, timeout=timeout) as response:\n",
+    "        charset = response.headers.get_content_charset() or \"utf-8\"\n",
+    "        return response.read().decode(charset, errors=\"replace\")\n",
+    "\n",
+    "\n",
+    "def extract_answer_list(html: str) -> list[str]:\n",
+    "    parser = MainAnswerListParser()\n",
+    "    parser.feed(html)\n",
+    "    return parser.items\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch and extract answers\n",
+    "\n",
+    "Set `url` to the NYTBee page you want to scrape, then run the cell.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = DEFAULT_URL\n",
+    "\n",
+    "try:\n",
+    "    html = fetch_html(url, timeout=20)\n",
+    "except HTTPError as exc:\n",
+    "    raise SystemExit(f\"HTTP error fetching {url}: {exc}\")\n",
+    "except URLError as exc:\n",
+    "    raise SystemExit(f\"URL error fetching {url}: {exc}\")\n",
+    "\n",
+    "items = extract_answer_list(html)\n",
+    "if not items:\n",
+    "    raise SystemExit(\"No answers extracted from the page.\")\n",
+    "\n",
+    "print(\"\\n\".join(items))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
### Motivation
- Extract the NYTBee answers specifically from the HTML element with id `main-answer-list` and return only the contents of the list items (`li`) instead of dumping all visible text.

### Description
- Replace the generic `TagTextExtractor` with a `MainAnswerListParser` that tracks `div` depth, detects the `div` with `id="main-answer-list"`, and collects text from `li` elements within nested `ul` blocks.
- Add the `extract_answer_list` function and update the notebook end-to-end flow to fetch HTML with `fetch_html`, parse with `extract_answer_list`, and print the joined items.
- Update notebook text and default behavior in `scrape_nytbee.ipynb` so the narrative and output reflect the new list-item extraction.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cef2f02a08333be7b0eb6977a33b4)