### PR TITLE
Add interactive prompts, per-URL progress, and output file to NYTBee scraper

### DIFF
--- a/scrape_nytbee.ipynb
+++ b/scrape_nytbee.ipynb
@@ -1,179 +1,144 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# NYTBee Scraper\n",
-    "\n",
-    "This notebook fetches a NYTBee page and extracts the list items from the main answer list.\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# NYTBee Scraper\n",
+        "\n",
+        "This notebook fetches a NYTBee page and extracts the list items from the main answer list.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from __future__ import annotations\n",
+        "\n",
+        "from datetime import date, timedelta\n",
+        "\n",
+        "import argparse\n",
+        "from html.parser import HTMLParser\n",
+        "from typing import Optional\n",
+        "from urllib.error import HTTPError, URLError\n",
+        "from urllib.request import Request, urlopen\n",
+        "\n",
+        "DEFAULT_URL = \"https://nytbee.com/Bee_20260130.html\"\n",
+        "USER_AGENT = \"Mozilla/5.0 (compatible; NYTBeeScraper/1.0)\"\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "class MainAnswerListParser(HTMLParser):\n",
+        "    \"\"\"Extract list items from the main answer list.\"\"\"\n",
+        "\n",
+        "    def __init__(self) -> None:\n",
+        "        super().__init__(convert_charrefs=True)\n",
+        "        self._div_depth = 0\n",
+        "        self._target_div_depth: Optional[int] = None\n",
+        "        self._ul_depth = 0\n",
+        "        self._li_stack: list[list[str]] = []\n",
+        "        self._items: list[str] = []\n",
+        "        self._skip_depth = 0\n",
+        "\n",
+        "    @property\n",
+        "    def items(self) -> list[str]:\n",
+        "        return self._items\n",
+        "\n",
+        "    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:\n",
+        "        if tag in {\"script\", \"style\"}:\n",
+        "            self._skip_depth += 1\n",
+        "            return\n",
+        "        if tag == \"div\":\n",
+        "            self._div_depth += 1\n",
+        "            if self._target_div_depth is None and dict(attrs).get(\"id\") == \"main-answer-list\":\n",
+        "                self._target_div_depth = self._div_depth\n",
+        "            return\n",
+        "        if self._target_div_depth is None or self._div_depth < self._target_div_depth:\n",
+        "            return\n",
+        "        if tag == \"ul\":\n",
+        "            self._ul_depth += 1\n",
+        "            return\n",
+        "        if tag == \"li\" and self._ul_depth:\n",
+        "            self._li_stack.append([])\n",
+        "\n",
+        "    def handle_endtag(self, tag: str) -> None:\n",
+        "        if tag in {\"script\", \"style\"} and self._skip_depth:\n",
+        "            self._skip_depth -= 1\n",
+        "            return\n",
+        "        if tag == \"li\" and self._li_stack:\n",
+        "            text = \"\".join(self._li_stack.pop()).strip()\n",
+        "            if text:\n",
+        "                self._items.append(text)\n",
+        "            return\n",
+        "        if tag == \"ul\" and self._ul_depth:\n",
+        "            self._ul_depth -= 1\n",
+        "            return\n",
+        "        if tag == \"div\":\n",
+        "            if self._target_div_depth is not None and self._div_depth == self._target_div_depth:\n",
+        "                self._target_div_depth = None\n",
+        "            if self._div_depth:\n",
+        "                self._div_depth -= 1\n",
+        "\n",
+        "    def handle_data(self, data: str) -> None:\n",
+        "        if self._skip_depth or not self._li_stack:\n",
+        "            return\n",
+        "        self._li_stack[-1].append(data)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def fetch_html(url: str, timeout: int = 20) -> str:\n",
+        "    request = Request(url, headers={\"User-Agent\": USER_AGENT})\n",
+        "    with urlopen(request, timeout=timeout) as response:\n",
+        "        charset = response.headers.get_content_charset() or \"utf-8\"\n",
+        "        return response.read().decode(charset, errors=\"replace\")\n",
+        "\n",
+        "\n",
+        "def extract_answer_list(html: str) -> list[str]:\n",
+        "    parser = MainAnswerListParser()\n",
+        "    parser.feed(html)\n",
+        "    return parser.items\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Fetch and extract answers\n",
+        "\n",
+        "Set `url` to the NYTBee page you want to scrape, then run the cell.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "base_url = \"https://nytbee.com/Bee_{date}.html\"\n\nstart_input = input(\"Enter start date (YYYY-MM-DD) [default: today]: \").strip()\nif start_input:\n    starting_date = date.fromisoformat(start_input)\nelse:\n    starting_date = date.today()\n\nwhile True:\n    days_input = input(\"Enter number of days to collect: \").strip()\n    try:\n        days_to_collect = int(days_input)\n        if days_to_collect <= 0:\n            raise ValueError(\"Number of days must be positive\")\n    except ValueError:\n        print(\"Please enter a positive integer for the number of days.\")\n        continue\n    break\n\nword_counts: dict[str, int] = {}\nfailed_urls: list[tuple[str, object]] = []\n\nfor offset in range(days_to_collect):\n    target_date = starting_date - timedelta(days=offset)\n    url = base_url.format(date=target_date.strftime(\"%Y%m%d\"))\n\n    print(f\"Collecting {url}...\")\n    try:\n        html = fetch_html(url, timeout=20)\n    except (HTTPError, URLError) as exc:\n        failed_urls.append((url, exc))\n        print(f\"  Failed: {exc}\")\n        continue\n\n    items = extract_answer_list(html)\n    if not items:\n        failed_urls.append((url, \"No answers extracted\"))\n        print(\"  Failed: No answers extracted\")\n        continue\n\n    for item in items:\n        word = item.strip()\n        if word:\n            word_counts[word] = word_counts.get(word, 0) + 1\n    print(f\"  Collected {len(items)} words from {url}.\")\n\nprint(\n    f\"Collected {len(word_counts)} distinct words from {days_to_collect - len(failed_urls)} days.\"\n)\n\nwith open(\"nytbee_dict.txt\", \"w\", encoding=\"utf-8\") as file_handle:\n    file_handle.write(str(word_counts))\n\nprint(\"\nFirst 100 words in the dictionary:\")\nfor word in sorted(word_counts)[:100]:\n    print(word)\n\nif failed_urls:\n    print(\"\nSkipped the following URLs:\")\n    for url, reason in failed_urls:\n        print(f\"- {url} ({reason})\")\n"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from __future__ import annotations\n",
-    "\n",
-    "from datetime import date, timedelta\n",
-    "\n",
-    "import argparse\n",
-    "from html.parser import HTMLParser\n",
-    "from typing import Optional\n",
-    "from urllib.error import HTTPError, URLError\n",
-    "from urllib.request import Request, urlopen\n",
-    "\n",
-    "DEFAULT_URL = \"https://nytbee.com/Bee_20260130.html\"\n",
-    "USER_AGENT = \"Mozilla/5.0 (compatible; NYTBeeScraper/1.0)\"\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class MainAnswerListParser(HTMLParser):\n",
-    "    \"\"\"Extract list items from the main answer list.\"\"\"\n",
-    "\n",
-    "    def __init__(self) -> None:\n",
-    "        super().__init__(convert_charrefs=True)\n",
-    "        self._div_depth = 0\n",
-    "        self._target_div_depth: Optional[int] = None\n",
-    "        self._ul_depth = 0\n",
-    "        self._li_stack: list[list[str]] = []\n",
-    "        self._items: list[str] = []\n",
-    "        self._skip_depth = 0\n",
-    "\n",
-    "    @property\n",
-    "    def items(self) -> list[str]:\n",
-    "        return self._items\n",
-    "\n",
-    "    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:\n",
-    "        if tag in {\"script\", \"style\"}:\n",
-    "            self._skip_depth += 1\n",
-    "            return\n",
-    "        if tag == \"div\":\n",
-    "            self._div_depth += 1\n",
-    "            if self._target_div_depth is None and dict(attrs).get(\"id\") == \"main-answer-list\":\n",
-    "                self._target_div_depth = self._div_depth\n",
-    "            return\n",
-    "        if self._target_div_depth is None or self._div_depth < self._target_div_depth:\n",
-    "            return\n",
-    "        if tag == \"ul\":\n",
-    "            self._ul_depth += 1\n",
-    "            return\n",
-    "        if tag == \"li\" and self._ul_depth:\n",
-    "            self._li_stack.append([])\n",
-    "\n",
-    "    def handle_endtag(self, tag: str) -> None:\n",
-    "        if tag in {\"script\", \"style\"} and self._skip_depth:\n",
-    "            self._skip_depth -= 1\n",
-    "            return\n",
-    "        if tag == \"li\" and self._li_stack:\n",
-    "            text = \"\".join(self._li_stack.pop()).strip()\n",
-    "            if text:\n",
-    "                self._items.append(text)\n",
-    "            return\n",
-    "        if tag == \"ul\" and self._ul_depth:\n",
-    "            self._ul_depth -= 1\n",
-    "            return\n",
-    "        if tag == \"div\":\n",
-    "            if self._target_div_depth is not None and self._div_depth == self._target_div_depth:\n",
-    "                self._target_div_depth = None\n",
-    "            if self._div_depth:\n",
-    "                self._div_depth -= 1\n",
-    "\n",
-    "    def handle_data(self, data: str) -> None:\n",
-    "        if self._skip_depth or not self._li_stack:\n",
-    "            return\n",
-    "        self._li_stack[-1].append(data)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def fetch_html(url: str, timeout: int = 20) -> str:\n",
-    "    request = Request(url, headers={\"User-Agent\": USER_AGENT})\n",
-    "    with urlopen(request, timeout=timeout) as response:\n",
-    "        charset = response.headers.get_content_charset() or \"utf-8\"\n",
-    "        return response.read().decode(charset, errors=\"replace\")\n",
-    "\n",
-    "\n",
-    "def extract_answer_list(html: str) -> list[str]:\n",
-    "    parser = MainAnswerListParser()\n",
-    "    parser.feed(html)\n",
-    "    return parser.items\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Fetch and extract answers\n",
-    "\n",
-    "Set `url` to the NYTBee page you want to scrape, then run the cell.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "base_url = \"https://nytbee.com/Bee_{date}.html\"\n",
-    "\n",
-    "starting_date = date.today()\n",
-    "distinct_words: set[str] = set()\n",
-    "failed_urls: list[tuple[str, object]] = []\n",
-    "\n",
-    "for offset in range(30):\n",
-    "    target_date = starting_date - timedelta(days=offset)\n",
-    "    url = base_url.format(date=target_date.strftime(\"%Y%m%d\"))\n",
-    "\n",
-    "    try:\n",
-    "        html = fetch_html(url, timeout=20)\n",
-    "    except (HTTPError, URLError) as exc:\n",
-    "        failed_urls.append((url, exc))\n",
-    "        continue\n",
-    "\n",
-    "    items = extract_answer_list(html)\n",
-    "    if not items:\n",
-    "        failed_urls.append((url, \"No answers extracted\"))\n",
-    "        continue\n",
-    "\n",
-    "    for item in items:\n",
-    "        word = item.strip()\n",
-    "        if word:\n",
-    "            distinct_words.add(word)\n",
-    "\n",
-    "print(f\"Collected {len(distinct_words)} distinct words from {30 - len(failed_urls)} days.\")\n",
-    "for word in sorted(distinct_words):\n",
-    "    print(word)\n",
-    "\n",
-    "if failed_urls:\n",
-    "    print(\"\\nSkipped the following URLs:\")\n",
-    "    for url, reason in failed_urls:\n",
-    "        print(f\"- {url} ({reason})\")\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.x"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
### Motivation
- Make the scraper interactive by allowing the user to choose a `start date` and the number of days to collect instead of using a fixed 30-day window.
- Provide visible progress while fetching pages so the user can see which URLs succeeded or failed as the run proceeds.
- Persist the collected word dictionary to disk and make it easy to inspect a subset of results by printing the first 100 words and writing the full dictionary to `nytbee_dict.txt`.

### Description
- Replaced the fixed 30-day collection loop with an interactive input flow that reads a `start date` (YYYY-MM-DD) and `days_to_collect` and validates the integer input.
- Added per-URL progress `print` statements while fetching each `https://nytbee.com/Bee_{date}.html` URL and appended failures to a `failed_urls` list.
- Switched from a `set` of `distinct_words` to a `word_counts` dictionary to track frequencies, wrote the full `word_counts` mapping to `nytbee_dict.txt`, and printed the first 100 sorted words.
- Updated the notebook cell content in `scrape_nytbee.ipynb` accordingly and committed the changes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d11d03dac833382a8d0c8c1416511)