### PR TITLE
Add NYT Spelling Bee solver notebook

### DIFF
--- a/nytbee_solver.ipynb
+++ b/nytbee_solver.ipynb
@@ -1,0 +1,89 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# NYT Spelling Bee Solver\n",
+        "\n",
+        "Enter the Spelling Bee letters when prompted. The first letter is the required letter and must appear in every answer. The solver uses `nytbee_dict.txt` as the word list and prints hints in a format similar to the NYT Spelling Bee hint page.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from __future__ import annotations\n",
+        "\n",
+        "from collections import defaultdict\n",
+        "from pathlib import Path\n",
+        "\n",
+        "\n",
+        "def load_words(path: Path) -> list[str]:\n",
+        "    if not path.exists():\n",
+        "        raise FileNotFoundError(f\"Missing wordlist: {path}\")\n",
+        "    words = [line.strip().lower() for line in path.read_text().splitlines()]\n",
+        "    return [word for word in words if word.isalpha()]\n",
+        "\n",
+        "\n",
+        "def solve_spelling_bee(letters: str, wordlist_path: Path) -> tuple[list[str], list[str], str]:\n",
+        "    cleaned = ''.join(char for char in letters.lower() if char.isalpha())\n",
+        "    if len(cleaned) < 2:\n",
+        "        raise ValueError(\"Please provide at least two letters.\")\n",
+        "\n",
+        "    required = cleaned[0]\n",
+        "    allowed = set(cleaned)\n",
+        "\n",
+        "    words = [\n",
+        "        word\n",
+        "        for word in load_words(wordlist_path)\n",
+        "        if len(word) >= 4 and required in word and set(word) <= allowed\n",
+        "    ]\n",
+        "    pangrams = [word for word in words if set(cleaned) <= set(word)]\n",
+        "    return sorted(words), sorted(pangrams), cleaned\n",
+        "\n",
+        "\n",
+        "def print_hint_page(words: list[str], pangrams: list[str], letters: str) -> None:\n",
+        "    print('NYT Spelling Bee Hint Page')\n",
+        "    print('-' * 30)\n",
+        "    print(f\"Letters: {', '.join(letters)} (required: {letters[0]})\")\n",
+        "    print(f\"Total words: {len(words)}\")\n",
+        "    print(f\"Pangrams ({len(pangrams)}): {', '.join(pangrams) if pangrams else 'None'}\")\n",
+        "\n",
+        "    grouped: dict[int, list[str]] = defaultdict(list)\n",
+        "    for word in words:\n",
+        "        grouped[len(word)].append(word)\n",
+        "\n",
+        "    for length in sorted(grouped):\n",
+        "        word_list = ', '.join(sorted(grouped[length]))\n",
+        "        print(f\"{length} letters ({len(grouped[length])}): {word_list}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "letters_input = input('Enter the Spelling Bee letters (required letter first): ')\n",
+        "words, pangrams, cleaned_letters = solve_spelling_bee(letters_input, Path('nytbee_dict.txt'))\n",
+        "print_hint_page(words, pangrams, cleaned_letters)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive Jupyter notebook that solves the New York Times Spelling Bee puzzle from a local wordlist.
- The solver should accept letters with the first letter treated as the required letter and display results in a hint-style layout similar to the NYT page.

### Description
- Add `nytbee_solver.ipynb` which prompts the user for letters and expects the first letter to be the required letter.
- Implement `load_words` to read `nytbee_dict.txt` and `solve_spelling_bee` which filters words to those of length >= 4 that contain the required letter and use only allowed letters, and which also detects pangrams.
- Implement `print_hint_page` which groups results by word length, prints totals and pangrams, and formats output in a style similar to the Spelling Bee hint page.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d13a3ac288333af8ef7bb53623605)