### PR TITLE
Strip carriage returns from scraped words and enforce LF for nytbee_dict.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+nytbee_dict.txt text eol=lf

--- a/scrape_nytbee.ipynb
+++ b/scrape_nytbee.ipynb
@@ -109,7 +109,7 @@
     "def extract_answer_list(html: str) -> list[str]:\n",
     "    parser = MainAnswerListParser()\n",
     "    parser.feed(html)\n",
-    "    return parser.items\n"
+    "    return [item.replace(\"\\r\", \"\") for item in parser.items]\n"
    ]
   },
   {


### PR DESCRIPTION
### Motivation
- HTML pages from nytbee.com include carriage returns which can leave `\r` in extracted words and pollute the local dictionary.  
- Ensure the stored dictionary uses consistent LF endings so downstream tools and notebooks see normalized text (`nytbee_dict.txt`).

### Description
- Add a `.gitattributes` file with the rule `nytbee_dict.txt text eol=lf` to enforce LF line endings for the dictionary file.  
- Normalize scraped words by updating `extract_answer_list` in `scrape_nytbee.ipynb` to return `[item.replace("\r", "") for item in parser.items]`, stripping carriage returns from each extracted item.  
- The change is limited to the extractor step so stored counts and subsequent consumers receive cleaned words.

### Testing
- No automated tests were run for this change.  
- The change was implemented and committed; please run the existing scrape workflow or unit checks against `extract_answer_list` to validate removal of `\r` characters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d254368fc8333b225e58bba07d109)