### PR TITLE
Strip non-alpha characters from scraped words and enforce LF for nytbee_dict.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+nytbee_dict.txt text eol=lf

--- a/scrape_nytbee.ipynb
+++ b/scrape_nytbee.ipynb
@@ -109,7 +109,7 @@
     "def extract_answer_list(html: str) -> list[str]:\n",
     "    parser = MainAnswerListParser()\n",
     "    parser.feed(html)\n",
-    "    return parser.items\n"
+    "    return [item.replace(\"\\r\", \"\") for item in parser.items]\n"
    ]
   },
   {
@@ -200,7 +200,8 @@
     "                continue\n",
     "\n",
     "            for item in items:\n",
-    "                word = item.strip()\n",
+    "                normalized = item.replace(\"\\r\", \"\").strip().lower()\n",
+    "                word = \"\".join(ch for ch in normalized if ch.isalpha())\n",
     "                if word:\n",
     "                    word_counts[word] = word_counts.get(word, 0) + 1\n",
     "            scraped_urls.add(url)\n",


### PR DESCRIPTION
### Motivation
- HTML from nytbee.com can include `\r` characters, inconsistent casing, and punctuation which can fragment the local dictionary and downstream processing. 
- Rather than ignoring entries that contain non-alphabetic characters, normalize them by keeping only alphabetic characters so valid words like "re-enter" become "reenter".

### Description
- Add a `.gitattributes` file with `nytbee_dict.txt text eol=lf` to enforce LF endings for the dictionary file.
- Update `extract_answer_list` in `scrape_nytbee.ipynb` to strip carriage returns by returning `[item.replace("\r", "") for item in parser.items]`.
- In the scrape loop, normalize each item with `normalized = item.replace("\r", "").strip().lower()` and produce the stored token with `word = "".join(ch for ch in normalized if ch.isalpha())` before counting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d254368fc8333b225e58bba07d109)