### PR TITLE
Add alphabetical solver output

### DIFF
--- a/nytbee_solver.ipynb
+++ b/nytbee_solver.ipynb
@@ -96,7 +96,10 @@
     "    print('\\nBy length:')\n",
     "    for length in sorted(grouped):\n",
     "        word_list = ', '.join(sorted(grouped[length]))\n",
-    "        print(f\"{length} letters ({len(grouped[length])}): {word_list}\")\n"
+    "        print(f\"{length} letters ({len(grouped[length])}): {word_list}\")\n",
+    "\n",
+    "    print('\\nAlphabetical:')\n",
+    "    print(', '.join(sorted(words)))\n"
    ]
   },
   {


### PR DESCRIPTION
### Motivation
- Add an alphabetical listing so the Spelling Bee solver presents answers both by word length and alphabetically.

### Description
- Update `print_hint_page` in `nytbee_solver.ipynb` to append an "Alphabetical" section that prints the full answer list with `', '.join(sorted(words))`.

### Testing
- No automated tests or CI were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e02f03f2c83339d2caa17f536bbe1)